### PR TITLE
Use configured dcacheParams instead of default

### DIFF
--- a/src/main/scala/common/Tile.scala
+++ b/src/main/scala/common/Tile.scala
@@ -165,7 +165,7 @@ class ShuttleTile private(
   frontend.resetVectorSinkNode := resetVectorNexusNode
 
   val nPTWPorts = 2 + roccs.map(_.nPTWPorts).sum
-  val dcache = LazyModule(new ShuttleDCache(tileId, ShuttleDCacheParams())(p))
+  val dcache = LazyModule(new ShuttleDCache(tileId, shuttleParams.dcacheParams)(p))
   (tlMasterXbar.node
     := TLBuffer()
     := tcmAdjusterNode(shuttleParams.tcm)


### PR DESCRIPTION
The dcache currently always uses a fresh instance of the default ShuttleDCacheParams rather than using the parameters provided in the config. This PR fixes that.