### PR TITLE
JTAG fix for shuttle

### DIFF
--- a/src/main/scala/exu/Core.scala
+++ b/src/main/scala/exu/Core.scala
@@ -451,7 +451,9 @@ class ShuttleCore(tile: ShuttleTile, edge: TLEdgeOut)(implicit p: Parameters) ex
       (stall_due_to_older)                     ||
       (csr.io.csr_stall)                       ||
       (ex_stall)                               ||
-      (io.traceStall)
+      (io.traceStall)                          ||
+      (csr.io.singleStep && (ex_bsy || mem_bsy || com_bsy)) || // drain instructions once single-step instruction is executing
+      (csr.io.singleStep && (i != 0).B) // only allow lane 0 to execute when single-stepping
     )
 
     stall_due_to_older = rrd_stall(i) || is_youngest

--- a/src/main/scala/exu/Core.scala
+++ b/src/main/scala/exu/Core.scala
@@ -742,6 +742,11 @@ class ShuttleCore(tile: ShuttleTile, edge: TLEdgeOut)(implicit p: Parameters) ex
     val ctrl = uop.ctrl
     when (mem_uops_reg(i).valid && mem_uops_reg(i).bits.ctrl.jalr && csr.io.status.debug) {
       io.imem.flush_icache := true.B
+      // Flush pipeline in Shuttle style
+      flush_rrd_ex := true.B
+      io.imem.redirect_val := true.B
+      io.imem.redirect_flush := true.B
+      io.imem.redirect_pc := mem_brjmp_npc
     }
     when (mem_brjmp_oh(i) && mem_uops_reg(i).bits.ctrl.jalr) {
       com_uops_reg(i).bits.wdata.valid := true.B


### PR DESCRIPTION
Originally, JTAG hung when trying to connect with openocd. We added the following edits in the Shuttle core to fix this and tested it in sim and on FPGA:
- Additional logic to flush the pipeline and handle jalr instructions in debug mode
- Single-step logic
Additional credit to Christian (@chrisrq) and Alonzo (@Uhhlonzo) for debugging this with me.